### PR TITLE
Fix constant re-fetching of repo data

### DIFF
--- a/randyhub/src/routes/GitRepo/index.js
+++ b/randyhub/src/routes/GitRepo/index.js
@@ -45,7 +45,7 @@ const GitRepo = () => {
     };
 
     fetchRepoData();
-  });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
Currently it is firing on every render. To prevent this, we can pass values that it can depend on. In this case, nothing.

Fixes #9 